### PR TITLE
feat(CU-86b18cx64): add base page, include header + sidebar

### DIFF
--- a/front/.vscode/launch.json
+++ b/front/.vscode/launch.json
@@ -17,7 +17,7 @@
       "url": "http://localhost:9876/debug.html"
     },
     {
-      "type": "debug",
+      "type": "chrome",
       "request": "launch",
       "name": "Lanzar Chrome contra localhost",
       "url": "http://localhost:4200",

--- a/front/angular.json
+++ b/front/angular.json
@@ -25,9 +25,10 @@
               "src/assets"
             ],
             "styles": [
-              "node_modules/primeng/resources/themes/lara-light-blue/theme.css",
+              "node_modules/primeng/resources/themes/lara-dark-cyan/theme.css",
               "node_modules/primeng/resources/primeng.min.css",
               "node_modules/bootstrap/dist/css/bootstrap-grid.min.css",
+              "src/normalize.css",
               "src/styles.css"
             ],
             "scripts": []

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,7 +17,8 @@
         "@angular/platform-browser-dynamic": "^17.3.0",
         "@angular/router": "^17.3.0",
         "bootstrap": "^5.3.3",
-        "primeng": "^17.16.1",
+        "primeicons": "^7.0.0",
+        "primeng": "^17.18.4",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -666,7 +667,7 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-define-polyfill-provider":{
+    "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.6.2",
       "dev": true,
       "license": "MIT",
@@ -8722,17 +8723,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/primeicons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-7.0.0.tgz",
+      "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==",
+      "license": "MIT"
+    },
     "node_modules/primeng": {
-      "version": "17.16.1",
-      "resolved": "https://registry.npmjs.org/primeng/-/primeng-17.16.1.tgz",
-      "integrity": "sha512-bNCUxdXgT4ikOG/aKA2PW9FCFnD/EtB+fLoGLuQXAGB1PJU72x5c0yQoGFDQcAgx78o3d/4LjZOdOPYwovN9Lg==",
+      "version": "17.18.4",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-17.18.4.tgz",
+      "integrity": "sha512-o1H9PHLpwuGRgzf9MCuH/pGKMYSYP4x3g3rydinul0u4YMYMKnqacu/+u8JEPM2FVt8p+6n/gD2V3Z4DTaFWgQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": "^17.0.0",
-        "@angular/core": "^17.0.0",
-        "@angular/forms": "^17.0.0",
+        "@angular/common": "^17.0.0 || ^18.0.0",
+        "@angular/core": "^17.0.0 || ^18.0.0",
+        "@angular/forms": "^17.0.0 || ^18.0.0",
         "rxjs": "^6.0.0 || ^7.8.1",
         "zone.js": "~0.14.0"
       }

--- a/front/package.json
+++ b/front/package.json
@@ -19,7 +19,8 @@
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
     "bootstrap": "^5.3.3",
-    "primeng": "^17.16.1",
+    "primeicons": "^7.0.0",
+    "primeng": "^17.18.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"

--- a/front/src/app/app.component.css
+++ b/front/src/app/app.component.css
@@ -1,0 +1,5 @@
+.header{
+  display: inline-block;
+  height: 65px;
+  width: 100vw;
+}

--- a/front/src/app/app.component.html
+++ b/front/src/app/app.component.html
@@ -1,13 +1,5 @@
-<div class="container my-4">
-  <div class="my-3">
-    <p-card header="Proyecto Final">
-      <p class="m-0">
-          Estos componentes fueron agregados para validar la correcta importación de las librerias
-      </p>
-    </p-card>
-  </div>
-  <div class="card flex justify-content-center">
-    <p-toast [life]="3500"/>
-    <p-button pRipple (click)="showToast()" label="Show" />
-</div>
+<app-header (toggleSidebar)="toggleSidebar()"></app-header>
+<app-sidebar [visible]="isSidebarVisible" (hide)="toggleSidebar()"></app-sidebar>
+<div>
+  <router-outlet></router-outlet>
 </div>

--- a/front/src/app/app.component.ts
+++ b/front/src/app/app.component.ts
@@ -4,18 +4,25 @@ import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { ToastModule } from 'primeng/toast';
+import { HeaderComponent } from './shared/header/header.component';
+import { SidebarComponent } from './shared/sidebar/sidebar.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, ButtonModule, CardModule, ToastModule],
+  imports: [RouterOutlet, ButtonModule, CardModule, ToastModule, HeaderComponent, SidebarComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
 export class AppComponent {
-  title = 'front';
+  isSidebarVisible: boolean = false;
 
-  constructor(private messageService: MessageService) { }
+  toggleSidebar() {
+    this.isSidebarVisible = !this.isSidebarVisible;
+  }
+
+
+ constructor(private messageService: MessageService) { }
 
   showToast() {
     this.messageService.add({ severity: 'success', summary: 'Bienvenido', detail: 'YAY! el toast funciona' });

--- a/front/src/app/components/user-info/user-info.component.css
+++ b/front/src/app/components/user-info/user-info.component.css
@@ -1,0 +1,3 @@
+::ng-deep .p-submenu-list{
+    width: 100% !important;
+}

--- a/front/src/app/components/user-info/user-info.component.html
+++ b/front/src/app/components/user-info/user-info.component.html
@@ -1,0 +1,1 @@
+<p-menubar [model]="items" [style]="menubarStyle"/>

--- a/front/src/app/components/user-info/user-info.component.ts
+++ b/front/src/app/components/user-info/user-info.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { MenuItem } from 'primeng/api';
+import { MenubarModule } from 'primeng/menubar';
+
+@Component({
+  selector: 'app-user-info',
+  standalone: true,
+  imports: [MenubarModule],
+  templateUrl: './user-info.component.html',
+  styleUrl: './user-info.component.css'
+})
+export class UserInfoComponent {
+  menubarStyle = {
+    border: 'none',
+    fontSize: '0.85rem'
+  };
+
+  items: MenuItem[] = [{
+    label: 'Juan Carlos',
+    icon: 'pi pi-user',
+    items:[
+      {
+        label: 'Cerrar sesión',
+        icon: 'pi pi-power-off'
+      }
+    ]
+  }];
+}

--- a/front/src/app/shared/header/header.component.html
+++ b/front/src/app/shared/header/header.component.html
@@ -1,0 +1,10 @@
+<p-menubar [style]="menubarStyle">
+    <ng-template pTemplate="start">
+        <span class="pi pi-bars px-2" (click)="toggle()"></span>
+    </ng-template>
+    <ng-template pTemplate="end">
+        <div class="px-2">
+            <app-user-info></app-user-info>
+        </div>
+    </ng-template>
+</p-menubar>

--- a/front/src/app/shared/header/header.component.ts
+++ b/front/src/app/shared/header/header.component.ts
@@ -1,0 +1,23 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { MenubarModule } from 'primeng/menubar';
+import { UserInfoComponent } from '../../components/user-info/user-info.component';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [MenubarModule, UserInfoComponent],
+  templateUrl: './header.component.html',
+  styleUrl: './header.component.css'
+})
+export class HeaderComponent {
+  @Output() toggleSidebar = new EventEmitter;
+
+  menubarStyle = {
+    borderRadius: '0px',
+    height: '100%'
+  };
+  
+  toggle(){
+    this.toggleSidebar.emit()
+  }
+}

--- a/front/src/app/shared/sidebar/sidebar.component.css
+++ b/front/src/app/shared/sidebar/sidebar.component.css
@@ -1,0 +1,6 @@
+.footer-text{
+    font-size: .75rem;
+    position: absolute;
+    bottom: 0px;
+    left: 15%;
+}

--- a/front/src/app/shared/sidebar/sidebar.component.html
+++ b/front/src/app/shared/sidebar/sidebar.component.html
@@ -1,0 +1,9 @@
+<p-sidebar [(visible)]="visible" [style]="sidebarStyle" (onHide)="hideEmit()">
+    <h3>Menú</h3>
+    <p-menu [model]="items" [style]="menubarStyle"/>
+    <div class="footer-text mt-auto">   
+        <p>
+            Made with 💕 by La Azul y Oro -&nbsp;{{year}} 
+        </p>
+    </div>
+</p-sidebar>

--- a/front/src/app/shared/sidebar/sidebar.component.ts
+++ b/front/src/app/shared/sidebar/sidebar.component.ts
@@ -1,0 +1,63 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MenuItem } from 'primeng/api';
+import { SidebarModule } from 'primeng/sidebar';
+import { MenuModule } from 'primeng/menu';
+
+@Component({
+  selector: 'app-sidebar',
+  standalone: true,
+  imports: [SidebarModule, MenuModule],
+  templateUrl: './sidebar.component.html',
+  styleUrl: './sidebar.component.css'
+})
+export class SidebarComponent {
+  @Input() visible : boolean = false;
+  @Output() hide = new EventEmitter;
+
+  year : number = new Date().getFullYear();
+
+  menubarStyle = {
+    width: '100%',
+  };
+
+  items: MenuItem[] = [{
+    label: 'Clientes',
+    icon: 'pi pi-users',
+  },
+  {
+    label: 'Pagos',
+    icon: 'pi pi-wallet'
+  },
+  {
+    label: 'Servicios',
+    icon: 'pi pi-history',
+  },
+  {
+    label: 'Vehiculos',
+    icon: 'pi pi-car',
+  },
+  {
+    label: 'Inventario',
+    icon: 'pi pi-objects-column'
+  },
+  {
+    label: 'Marcas',
+    icon: 'pi pi-sparkles'
+  },
+  {
+    label: 'Proveedores',
+    icon: 'pi pi-warehouse',
+  },
+  {
+    label: 'Repuestos',
+    icon: 'pi pi-wrench',
+  }];
+
+  sidebarStyle = {
+    border: 'none',
+  };
+
+  hideEmit(){
+    this.hide.emit();
+  }
+}

--- a/front/src/normalize.css
+++ b/front/src/normalize.css
@@ -1,0 +1,350 @@
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+ html {
+    line-height: 1.15; /* 1 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+  }
+  
+  /* Sections
+     ========================================================================== */
+  
+  /**
+   * Remove the margin in all browsers.
+   */
+  
+  body {
+    margin: 0;
+  }
+  
+  /**
+   * Render the `main` element consistently in IE.
+   */
+  
+  main {
+    display: block;
+  }
+  
+  /**
+   * Correct the font size and margin on `h1` elements within `section` and
+   * `article` contexts in Chrome, Firefox, and Safari.
+   */
+  
+  h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+  }
+  
+  /* Grouping content
+     ========================================================================== */
+  
+  /**
+   * 1. Add the correct box sizing in Firefox.
+   * 2. Show the overflow in Edge and IE.
+   */
+  
+  hr {
+    box-sizing: content-box; /* 1 */
+    height: 0; /* 1 */
+    overflow: visible; /* 2 */
+  }
+  
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+  
+  pre {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+  
+  /* Text-level semantics
+     ========================================================================== */
+  
+  /**
+   * Remove the gray background on active links in IE 10.
+   */
+  
+  a {
+    background-color: transparent;
+  }
+  
+  /**
+   * 1. Remove the bottom border in Chrome 57-
+   * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+   */
+  
+  abbr[title] {
+    border-bottom: none; /* 1 */
+    text-decoration: underline; /* 2 */
+    text-decoration: underline dotted; /* 2 */
+  }
+  
+  /**
+   * Add the correct font weight in Chrome, Edge, and Safari.
+   */
+  
+  b,
+  strong {
+    font-weight: bolder;
+  }
+  
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+  
+  code,
+  kbd,
+  samp {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+  
+  /**
+   * Add the correct font size in all browsers.
+   */
+  
+  small {
+    font-size: 80%;
+  }
+  
+  /**
+   * Prevent `sub` and `sup` elements from affecting the line height in
+   * all browsers.
+   */
+  
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  
+  sub {
+    bottom: -0.25em;
+  }
+  
+  sup {
+    top: -0.5em;
+  }
+  
+  /* Embedded content
+     ========================================================================== */
+  
+  /**
+   * Remove the border on images inside links in IE 10.
+   */
+  
+  img {
+    border-style: none;
+  }
+  
+  /* Forms
+     ========================================================================== */
+  
+  /**
+   * 1. Change the font styles in all browsers.
+   * 2. Remove the margin in Firefox and Safari.
+   */
+  
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit; /* 1 */
+    font-size: 100%; /* 1 */
+    line-height: 1.15; /* 1 */
+    margin: 0; /* 2 */
+  }
+  
+  /**
+   * Show the overflow in IE.
+   * 1. Show the overflow in Edge.
+   */
+  
+  button,
+  input { /* 1 */
+    overflow: visible;
+  }
+  
+  /**
+   * Remove the inheritance of text transform in Edge, Firefox, and IE.
+   * 1. Remove the inheritance of text transform in Firefox.
+   */
+  
+  button,
+  select { /* 1 */
+    text-transform: none;
+  }
+  
+  /**
+   * Correct the inability to style clickable types in iOS and Safari.
+   */
+  
+  button,
+  [type="button"],
+  [type="reset"],
+  [type="submit"] {
+    -webkit-appearance: button;
+  }
+  
+  /**
+   * Remove the inner border and padding in Firefox.
+   */
+  
+  button::-moz-focus-inner,
+  [type="button"]::-moz-focus-inner,
+  [type="reset"]::-moz-focus-inner,
+  [type="submit"]::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+  
+  /**
+   * Restore the focus styles unset by the previous rule.
+   */
+  
+  button:-moz-focusring,
+  [type="button"]:-moz-focusring,
+  [type="reset"]:-moz-focusring,
+  [type="submit"]:-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+  
+  /**
+   * Correct the padding in Firefox.
+   */
+  
+  fieldset {
+    padding: 0.35em 0.75em 0.625em;
+  }
+  
+  /**
+   * 1. Correct the text wrapping in Edge and IE.
+   * 2. Correct the color inheritance from `fieldset` elements in IE.
+   * 3. Remove the padding so developers are not caught out when they zero out
+   *    `fieldset` elements in all browsers.
+   */
+  
+  legend {
+    box-sizing: border-box; /* 1 */
+    color: inherit; /* 2 */
+    display: table; /* 1 */
+    max-width: 100%; /* 1 */
+    padding: 0; /* 3 */
+    white-space: normal; /* 1 */
+  }
+  
+  /**
+   * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+   */
+  
+  progress {
+    vertical-align: baseline;
+  }
+  
+  /**
+   * Remove the default vertical scrollbar in IE 10+.
+   */
+  
+  textarea {
+    overflow: auto;
+  }
+  
+  /**
+   * 1. Add the correct box sizing in IE 10.
+   * 2. Remove the padding in IE 10.
+   */
+  
+  [type="checkbox"],
+  [type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+  }
+  
+  /**
+   * Correct the cursor style of increment and decrement buttons in Chrome.
+   */
+  
+  [type="number"]::-webkit-inner-spin-button,
+  [type="number"]::-webkit-outer-spin-button {
+    height: auto;
+  }
+  
+  /**
+   * 1. Correct the odd appearance in Chrome and Safari.
+   * 2. Correct the outline style in Safari.
+   */
+  
+  [type="search"] {
+    -webkit-appearance: textfield; /* 1 */
+    outline-offset: -2px; /* 2 */
+  }
+  
+  /**
+   * Remove the inner padding in Chrome and Safari on macOS.
+   */
+  
+  [type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  
+  /**
+   * 1. Correct the inability to style clickable types in iOS and Safari.
+   * 2. Change font properties to `inherit` in Safari.
+   */
+  
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button; /* 1 */
+    font: inherit; /* 2 */
+  }
+  
+  /* Interactive
+     ========================================================================== */
+  
+  /*
+   * Add the correct display in Edge, IE 10+, and Firefox.
+   */
+  
+  details {
+    display: block;
+  }
+  
+  /*
+   * Add the correct display in all browsers.
+   */
+  
+  summary {
+    display: list-item;
+  }
+  
+  /* Misc
+     ========================================================================== */
+  
+  /**
+   * Add the correct display in IE 10+.
+   */
+  
+  template {
+    display: none;
+  }
+  
+  /**
+   * Add the correct display in IE 10.
+   */
+  
+  [hidden] {
+    display: none;
+  }
+  

--- a/front/src/styles.css
+++ b/front/src/styles.css
@@ -1,1 +1,1 @@
-/* You can add global styles to this file, and also import other style files */
+@import "primeicons/primeicons.css";


### PR DESCRIPTION
Dejo pantallita base para el front, le agregue un header y un sidebar que son elementos en comun conforme cambiemos de componentes.
Respecto al color, si luego quieren usamos otro tema de los que ofrece la libreria, puse eso, porque fan de los oscuros, jajajaj, dejo capturas de lo agregado:

![imagen](https://github.com/user-attachments/assets/d850d91c-3c9a-4f83-b89d-94940016434f)

y asi cuando el sidebar esta oculto:
![imagen](https://github.com/user-attachments/assets/5effaddd-206b-49db-a8b4-a2fe50a9f485)
