### PR TITLE
feat(CU-86b193ycu): add table to visualize Client data

### DIFF
--- a/back/src/main/java/com/azulyoro/back/controller/ClientController.java
+++ b/back/src/main/java/com/azulyoro/back/controller/ClientController.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/clients")
+@CrossOrigin
 public class ClientController {
     @Autowired
     private EntityService<ClientRequestDto, ClientResponseDto> service;

--- a/front/src/app/app.component.css
+++ b/front/src/app/app.component.css
@@ -3,3 +3,8 @@
   height: 65px;
   width: 100vw;
 }
+
+.main-content {
+  height: calc(100vh - 75px) !important;
+  overflow: hidden;
+}

--- a/front/src/app/app.component.html
+++ b/front/src/app/app.component.html
@@ -1,5 +1,5 @@
 <app-header (toggleSidebar)="toggleSidebar()"></app-header>
 <app-sidebar [visible]="isSidebarVisible" (hide)="toggleSidebar()"></app-sidebar>
-<div>
+<div class="container main-content py-2">
   <router-outlet></router-outlet>
 </div>

--- a/front/src/app/app.config.ts
+++ b/front/src/app/app.config.ts
@@ -4,7 +4,13 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { MessageService } from 'primeng/api';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes), MessageService, provideAnimations()]
+  providers: [
+    provideRouter(routes), 
+    provideHttpClient(),
+    MessageService, 
+    provideAnimations()
+  ]
 };

--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -1,3 +1,6 @@
 import { Routes } from '@angular/router';
+import { ClientComponent } from './pages/client/client.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+    { path: 'clientes', component: ClientComponent },
+];

--- a/front/src/app/components/page/page.component.css
+++ b/front/src/app/components/page/page.component.css
@@ -1,0 +1,4 @@
+::ng-deep .p-datatable-header{
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+} 

--- a/front/src/app/components/page/page.component.html
+++ b/front/src/app/components/page/page.component.html
@@ -1,0 +1,119 @@
+<div class="d-flex flex-column">
+  <div class="row">
+    <div class="col-6">
+      <h3>{{ title }}</h3>
+    </div>
+    <div class="col-6 align-self-center d-flex justify-content-end">
+      <p-button
+        label="{{ labelButtonAdd }}"
+        icon="pi pi-plus"
+        [style]="buttonStyle"
+        size="small"
+        (onClick)="create()"
+      />
+    </div>
+  </div>
+  <div class="row" id="table" style="overflow: auto">
+    <p-table
+      #table
+      [columns]="cols"
+      [scrollable]="true"
+      scrollHeight="calc(100vh - 270px)"
+      [value]="data ?? []"
+      [rows]="10"
+      [rowsPerPageOptions]="[10, 25, 50]"
+      [paginator]="true"
+      [tableStyle]="{ 'min-width': '50rem' }"
+      [rowHover]="true"
+      dataKey="id"
+      [styleClass]="'p-datatable-striped p-datatable-gridlines'"
+      [style]="buttonStyle"
+      [resizableColumns]="true" 
+    >
+      <ng-template pTemplate="caption">
+        <div class="flex">
+            <p-iconField iconPosition="left" class="ml-auto" styleClass="iconFieldStyle">
+                <p-inputIcon>
+                    <i class="pi pi-search"></i>
+                </p-inputIcon>
+                <input 
+                    pInputText 
+                    type="text" 
+                    (input)="filter($event)" 
+                    placeholder="Buscar" />
+            </p-iconField>
+        </div>
+      </ng-template>
+      <ng-template pTemplate="header" let-columns>
+        <tr>
+          <th *ngFor="let col of columns">
+            <ng-container *ngIf="col.sortable; else nonSortable">
+              <span pSortableColumn="{{ col.field }}">
+                {{ col.header }}
+                <p-sortIcon field="{{ col.field }}"></p-sortIcon>
+              </span>
+            </ng-container>
+            <ng-template #nonSortable>
+              {{ col.header }}
+            </ng-template>
+          </th>
+
+          <th>Acciones</th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-rowData let-columns="columns">
+        <tr>
+          <td *ngFor="let col of columns">
+            {{ rowData[col.field] }}
+          </td>
+          <td>
+            <div class="d-flex">
+              <p-button
+                icon="pi pi-link"
+                [pTooltip]="tooltipLink"
+                [rounded]="true"
+                [outlined]="true"
+                severity="info"
+                size="small"
+                [style]="styleButtonAction"
+                (onClick)="link(rowData)"
+              />
+              <ng-template #tooltipLink>
+                <span style="font-size: 13px">Ver elementos relacionados</span>
+              </ng-template>
+              <p-button
+                pRipple
+                icon="pi pi-pencil"
+                [pTooltip]="tooltipEdit"
+                class="mx-2"
+                [rounded]="true"
+                [outlined]="true"
+                severity="success"
+                size="small"
+                [style]="styleButtonAction"
+                (onClick)="edit(rowData)"
+              />
+              <ng-template #tooltipEdit>
+                <span style="font-size: 13px">Editar registro</span>
+              </ng-template>
+              <p-button
+                pRipple
+                icon="pi pi-trash"
+                severity="danger"
+                [pTooltip]="tooltipDelete"
+                [rounded]="true"
+                [outlined]="true"
+                size="small"
+                [style]="styleButtonAction"
+                (onClick)="remove(rowData)"
+              />
+              <ng-template #tooltipDelete>
+                <span style="font-size: 13px">Borrar registro</span>
+              </ng-template>
+            </div>
+          </td>
+        </tr>
+      </ng-template>
+    </p-table>
+  </div>
+</div>

--- a/front/src/app/components/page/page.component.ts
+++ b/front/src/app/components/page/page.component.ts
@@ -1,0 +1,73 @@
+import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { Table, TableModule } from 'primeng/table';
+import { ButtonModule } from 'primeng/button';
+import { TooltipModule } from 'primeng/tooltip';
+import { IconFieldModule } from 'primeng/iconfield';
+import { InputIconModule } from 'primeng/inputicon';
+import { InputTextModule } from 'primeng/inputtext';
+import { CommonModule } from '@angular/common';
+import { Column } from '../../interfaces/table.interface';
+
+@Component({
+  selector: 'app-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ButtonModule,
+    IconFieldModule, 
+    InputTextModule, 
+    InputIconModule,
+    TableModule,
+    TooltipModule],
+  templateUrl: './page.component.html',
+  styleUrl: './page.component.css'
+})
+export class PageComponent {
+  @ViewChild('table') dt!: Table;
+
+  @Input() title?: string = "";
+  @Input() labelButtonAdd?: string = "";
+  @Input() data? : any [] = [];
+  @Input() cols!: Column[];
+  
+  @Output() onCreate = new EventEmitter;
+  @Output() onEdit = new EventEmitter;
+  @Output() onDelete = new EventEmitter;
+  @Output() onLink = new EventEmitter;
+  
+  buttonStyle = {
+    fontSize: '0.8rem'
+  };
+
+  iconFieldStyle = {
+    fontSize: '0.8rem',
+    paddingTop: '0.5rem',
+    paddingBottom: '0.5rem',
+  };
+
+  styleButtonAction = {
+    height: '30px',
+    width: '30px', 
+    padding: '0px',
+  };
+
+  create(){
+    this.onCreate.emit();
+  }
+
+  link(item : any){
+    this.onLink.emit(item);
+  }
+
+  edit(item : any){
+    this.onEdit.emit(item);
+  }
+
+  remove(item : any){
+    this.onDelete.emit(item);
+  }
+
+  filter(event : any){
+    this.dt.filterGlobal(event.target.value, 'contains');
+  }
+}

--- a/front/src/app/interfaces/table.interface.ts
+++ b/front/src/app/interfaces/table.interface.ts
@@ -1,0 +1,5 @@
+export interface Column {
+    field: string;
+    header: string;
+    sortable?: boolean;
+}

--- a/front/src/app/pages/client/client.component.html
+++ b/front/src/app/pages/client/client.component.html
@@ -1,0 +1,11 @@
+<app-page
+    [title]="title"
+    [labelButtonAdd]="labelButtonAdd"
+    [data]="clientList"
+    [cols]="columns"
+    (onCreate)="createClient()"
+    (onEdit)="editClient($event)"
+    (onDelete)="deleteClient($event)"
+    (onLink)="linkClient($event)"
+>
+</app-page>

--- a/front/src/app/pages/client/client.component.ts
+++ b/front/src/app/pages/client/client.component.ts
@@ -1,0 +1,84 @@
+import { Component } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+import { TableModule } from 'primeng/table';
+import { ClientService } from '../../services/client.service';
+import { ClientResponse } from '../../interfaces/client';
+import { PageComponent } from '../../components/page/page.component';
+import { Column } from '../../interfaces/table.interface';
+
+@Component({
+  selector: 'app-client',
+  standalone: true,
+  imports: [ButtonModule, TableModule, PageComponent],
+  templateUrl: './client.component.html',
+  styleUrl: './client.component.css'
+})
+export class ClientComponent {
+  title : string = "Clientes";
+  labelButtonAdd : string = "Agregar cliente";
+
+  clientList : ClientResponse[] = [];
+
+  columns : Column []= [
+    {
+      header: "Nombre",
+      field: "name",
+      sortable: true
+    },
+    {
+      header: "Apellido",
+      field: "lastName",
+      sortable: true
+    },
+    {
+      header: "Tipo documento",
+      field: "category",
+      sortable: true
+    },
+    {
+      header: "Nro. documento",
+      field: "identificationNumber",
+      sortable: true
+    },
+    {
+      header: "Nombre empresa",
+      field: "businessName",
+      sortable: true
+    },
+    {
+      header: "E-mail",
+      field: "email",
+      sortable: true
+    }
+  ];
+
+  constructor(
+    private clientService : ClientService
+  ){}
+
+  ngOnInit(){
+    this.loadClients();
+  }
+
+  loadClients(){
+    this.clientService.getAll().subscribe(response => {
+      this.clientList = response;
+    });
+  }
+
+  createClient(){
+    alert("TODO crear sin implementar");
+  }
+
+  editClient(client : any){
+    alert("TODO editar sin implementar");
+  }
+
+  deleteClient(client : any){
+    alert("TODO borrar sin implementar");
+  }
+
+  linkClient(client : any){
+    alert("TODO relacionadas sin implementar");
+  }
+}

--- a/front/src/app/shared/sidebar/sidebar.component.html
+++ b/front/src/app/shared/sidebar/sidebar.component.html
@@ -1,6 +1,17 @@
 <p-sidebar [(visible)]="visible" [style]="sidebarStyle" (onHide)="hideEmit()">
     <h3>Menú</h3>
-    <p-menu [model]="items" [style]="menubarStyle"/>
+
+    <p-menu [model]="items">
+        <ng-template pTemplate="item" let-item>
+            <ng-container>
+                <a [routerLink]="item.path" class="p-menuitem-link">
+                    <span [class]="item.icon"></span>
+                    <span class="ms-2">{{ item.label }}</span>
+                </a>
+            </ng-container>
+        </ng-template>
+    </p-menu>
+
     <div class="footer-text mt-auto">   
         <p>
             Made with 💕 by La Azul y Oro -&nbsp;{{year}} 

--- a/front/src/app/shared/sidebar/sidebar.component.ts
+++ b/front/src/app/shared/sidebar/sidebar.component.ts
@@ -23,6 +23,7 @@ export class SidebarComponent {
   items: MenuItem[] = [{
     label: 'Clientes',
     icon: 'pi pi-users',
+    path: 'clientes'
   },
   {
     label: 'Pagos',

--- a/front/src/enviroments/enviroments.ts
+++ b/front/src/enviroments/enviroments.ts
@@ -1,4 +1,4 @@
 export const environment = {
     production: false,
-    apiUrl: 'http://localhost:8080/'
+    apiUrl: 'http://localhost:8080'
   };


### PR DESCRIPTION
Dejo captura de como queda la pantalla, aprovechando lo que da la libreria va con paginacion y ordenamiento por columnas, estuve laburando para que sea reutilizable toda esta parte: ver el archivo de **client.component.html**

![imagen](https://github.com/user-attachments/assets/d756a1e4-d6ef-4e16-9962-11331e6de61e)
